### PR TITLE
Allow weakauras style text formatting for next sound notif

### DIFF
--- a/Core/SoundManager.lua
+++ b/Core/SoundManager.lua
@@ -6,6 +6,13 @@ local addonName, addon = ...
 addon.SoundManager = {}
 local SoundManager = addon.SoundManager
 
+SoundManager.Substitutions = {
+    ["spellName"] = function (cooldownData)
+        local spell = addon.Config:GetSpellInfo(cooldownData.spellID)
+        return spell.name or "Next"
+    end,
+}
+
 function SoundManager:Initialize()
     -- Initialize throttling state
     self.lastNotificationTime = nil
@@ -13,13 +20,13 @@ function SoundManager:Initialize()
     -- Register for turn notification events
     if addon.CCRotation then
         addon.CCRotation:RegisterEventListener("PLAYER_TURN_NEXT", function(cooldownData)
-            self:PlayTurnNotification()
+            self:PlayTurnNotification(cooldownData)
         end)
     end
 end
 
 -- Play turn notification sound using text-to-speech
-function SoundManager:PlayTurnNotification()
+function SoundManager:PlayTurnNotification(cooldownData)
     -- Throttle notifications to prevent spam (only once per 5 seconds)
     local now = GetTime()
     if self.lastNotificationTime and (now - self.lastNotificationTime) < 5 then
@@ -29,9 +36,24 @@ function SoundManager:PlayTurnNotification()
     
     -- Get the configurable notification settings
     local config = addon.Config
-    local notificationText = config:Get("turnNotificationText") or "Next"
+    local notificationText = self:GetNotificationText(cooldownData)
     local volume = config:Get("turnNotificationVolume") or 100
     
     -- Use WoW's text-to-speech API to announce it's the player's turn
     C_VoiceChat.SpeakText(1, notificationText, Enum.VoiceTtsDestination.QueuedLocalPlayback, 1, volume)
+end
+
+function SoundManager:GetNotificationText(cooldownData) 
+    local notificationText = addon.Config:Get("turnNotificationText") or "Next"
+
+    -- Pattern explanation:
+    -- %% matches a literal % character
+    -- ([%w_]+) captures one or more word characters (letters, digits, underscore) as the key
+    return notificationText:gsub("%%([%w_]+)", function (key)
+        if self.Substitutions[key] then
+            return self.Substitutions[key](cooldownData)
+        end
+
+        return key
+    end)
 end


### PR DESCRIPTION
Fixes: nothing :)

Allows substituting the `next` spell notification with keyed values.
For example:
%spellName -> Blinding light
Use %spellName -> Use blinding light
Use %spellName next -> Use blinding light next