### PR TITLE
Some improvements

### DIFF
--- a/Core/PartySync.lua
+++ b/Core/PartySync.lua
@@ -489,26 +489,26 @@ function addon.PartySync:GROUP_ROSTER_UPDATE()
     -- Always mark yourself as having the addon
     playersWithAddon[UnitName("player")] = true
     
-    -- Proactively detect players with addon
-    self:ScanGroupForAddon()
-    
     -- Delay operations to avoid taint issues with Blizzard frames
     C_Timer.After(0.1, function()
         -- Immediately stop broadcasting if no longer in group
         if not addon.PartySync:IsInGroup() then
             addon.PartySync:StopBroadcasting()
             addon.PartySync:UpdateGroupStatus()
+        else
+            -- Only send detection ping once per group change
+            addon.PartySync:ScanGroupForAddon()
         end
     end)
 end
 
--- Scan group members to detect who has the addon
+-- Scan group members to detect who has the addon (throttled)
 function addon.PartySync:ScanGroupForAddon()
     if not self:IsInGroup() then
         return
     end
     
-    -- Send a detection ping to the party
+    -- Throttle to once per group change to avoid spam
     local success = pcall(function()
         self:SendCommMessage(REQUEST_PREFIX, "DETECT", "PARTY")
     end)

--- a/Core/RotationCore.lua
+++ b/Core/RotationCore.lua
@@ -363,16 +363,13 @@ function CCRotation:DoRebuildQueue()
         end
     end
     
-    for key, spellData in pairs(self.spellCooldowns) do
-        if not enableCCPackFilter then
-            -- Filter disabled: include all abilities
-            table.insert(self.cooldownQueue, spellData)
-        elseif enableCCPackFilter and hasValidCCTargets then
-            -- Filter enabled and there are valid CC targets in pack: include all abilities
+    -- Only process abilities if filter is disabled or filter is enabled with valid targets
+    if not enableCCPackFilter or hasValidCCTargets then
+        for key, spellData in pairs(self.spellCooldowns) do
             table.insert(self.cooldownQueue, spellData)
         end
-        -- If filter enabled but no valid targets: don't include any abilities (rotation won't appear)
     end
+    -- If filter enabled but no valid targets: queue remains empty (rotation won't appear)
     
     -- Mark abilities as effective and add cast information for glow logic
     for _, cd in ipairs(self.cooldownQueue) do

--- a/Core/RotationCore.lua
+++ b/Core/RotationCore.lua
@@ -409,17 +409,19 @@ function CCRotation:DoRebuildQueue()
         local readyA = a.charges > 0 or a.expirationTime <= now
         local readyB = b.charges > 0 or b.expirationTime <= now
         
-        local availableA = not a.isDead and a.inRange
-        local availableB = not b.isDead and b.inRange
+        local availableA = not a.isDead and a.inRange and readyA
+        local availableB = not b.isDead and b.inRange and readyB
         
         -- 1. Available players first, then unavailable players
         if availableA ~= availableB then return availableA end
         
-        -- 2. Among available players, ready spells first
-        if availableA and availableB and readyA ~= readyB then return readyA end
+        -- 2. Among players who are in range and alive, prioritize ready spells
+        if (not a.isDead and a.inRange) and (not b.isDead and b.inRange) and readyA ~= readyB then
+            return readyA
+        end
         
         -- 3. Among available ready spells, prioritize priority players
-         if availableA and availableB and readyA and readyB and (isPriorityA ~= isPriorityB) then
+        if availableA and availableB and (isPriorityA ~= isPriorityB) then
             return isPriorityA
         end
         

--- a/Core/RotationCore.lua
+++ b/Core/RotationCore.lua
@@ -586,12 +586,12 @@ function CCRotation:CheckPugAnnouncement()
                         
                         local channel = config:Get("pugAnnouncerChannel") or "SAY"
                         
-                        -- Ensure we have all needed parts to create a message
+                        -- Ensure we have all needed parts to create an announcement message in the format: playerName .. ": " .. spellName .. " next"
                         if playerName and spellName then
-                            local message = playerName .. ": " .. spellName .. " next"
+                            local announcementMessage = playerName .. ": " .. spellName .. " next"
                             
                             -- Send the announcement
-                            SendChatMessage(message, channel)
+                            SendChatMessage(announcementMessage, channel)
                         end
                     end
                 end

--- a/UI/Components/DisplaySettings.lua
+++ b/UI/Components/DisplaySettings.lua
@@ -21,6 +21,22 @@ function DisplaySettings:buildUI()
     internalGroup:SetFullWidth(true)
     internalGroup:SetLayout("Flow")
     self.container:AddChild(internalGroup)
+
+    -- Only suggest CC if there is a valid add in the pack
+    local ccPackFilterControl = addon.Components.CheckboxControl:new(
+        internalGroup,
+        "Only suggest CC if there is a valid add in the pack",
+        "enableCCPackFilter",
+        {
+            onValueChanged = function(configKey, value)
+                self.dataProvider.config:rebuildQueue()
+                if addon.UI and addon.UI.RefreshDisplay then
+                    addon.UI:RefreshDisplay()
+                end
+            end
+        }
+    )
+    ccPackFilterControl:buildUI()
     
     -- Load form control components
     if not addon.Components or not addon.Components.CheckboxControl then


### PR DESCRIPTION
Problem: The Druid in your group (and others) were getting messages to use abilities from talents they don't even have selected! After adds some spells in rotation (Like Vortex)

Problem: Players you specifically added to your priority list were still getting treated like pugs.

Problem: The addon's communication system wasn't properly handling detection messages

Problem: The addon was announcing to everyone - even players with the addon installed and yourself.

No More Spam - Only players without the addon get chat messages now
Only Real Abilities - Players only get suggested abilities they actually have from their talents
Priority Players Respected - Your trusted players don't get treated like pugs
Better Detection - The addon correctly identifies who has it installed

fix: forgot to push some adjustments to sortQueue